### PR TITLE
handler: Test that crits don’t count as ok

### DIFF
--- a/src/pager_event_handler_min_ok_tests.erl
+++ b/src/pager_event_handler_min_ok_tests.erl
@@ -29,11 +29,14 @@ next_event(Ref) ->
 
 enough_hosts({Ref, Pid}) ->
     {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_1">>}, {state, <<"ok">>}]),
-    {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_2">>}, {state, <<"ok">>}]),
-    {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_2">>}, {state, <<"critical">>}]),
     MsgNotEnough = next_event(Ref),
+
+    {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_2">>}, {state, <<"ok">>}]),
     MsgOk = next_event(Ref),
+
+    {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_2">>}, {state, <<"critical">>}]),
     MsgCritical = next_event(Ref),
+
     [?_assertEqual([{ok, [{state, critical}]}], MsgNotEnough),
      ?_assertEqual([{ok, [{state, ok}]}], MsgOk),
      ?_assertEqual([{ok, [{state, critical}]}], MsgCritical)].

--- a/src/pager_event_handler_min_ok_tests.erl
+++ b/src/pager_event_handler_min_ok_tests.erl
@@ -30,7 +30,10 @@ next_event(Ref) ->
 enough_hosts({Ref, Pid}) ->
     {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_1">>}, {state, <<"ok">>}]),
     {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_2">>}, {state, <<"ok">>}]),
-    MsgCritical = next_event(Ref),
+    {ok, _} = pager_event_handler_min_ok:send_event(Pid, [{service, <<"foo">>}, {pod, <<"bar">>}, {host, <<"host_2">>}, {state, <<"critical">>}]),
+    MsgNotEnough = next_event(Ref),
     MsgOk = next_event(Ref),
-    [?_assertEqual([{ok, [{state, critical}]}], MsgCritical),
-     ?_assertEqual([{ok, [{state, ok}]}], MsgOk)].
+    MsgCritical = next_event(Ref),
+    [?_assertEqual([{ok, [{state, critical}]}], MsgNotEnough),
+     ?_assertEqual([{ok, [{state, ok}]}], MsgOk),
+     ?_assertEqual([{ok, [{state, critical}]}], MsgCritical)].


### PR DESCRIPTION
Make sure that if a state is critical that it doesn’t count towards the
ok ones.
